### PR TITLE
修复了在Stellar Theme 版本1.22以上友链图标的异常

### DIFF
--- a/Stellar/friends.js
+++ b/Stellar/friends.js
@@ -8,11 +8,13 @@ function loadQexoFriends(id, url) {
             data.json().then(function(res){
                 if (res["status"]) {
                     var friends = res["data"];
-                    let content = "<div class=\"group-body\">";
+
+                    let ls = ["<div class=\"group-body\">" + "<div class=\"grid-box\">" ];
                     for (let i = 0; i < friends.length; i++) {
-                        content = `<div class="user-card" title="${friends[i]["description"]}"><a class="card-link" href="${friends[i]["url"]}" rel="external nofollow noopener noreferrer" target="_blank"><img onError="this.src='https://gcore.jsdelivr.net/gh/cdn-x/placeholder@1.0.4/avatar/round/3442075.svg';" src="${friends[i]["image"]}"><div class="name"><span>${friends[i]["name"]}</span></div></a></div>`;
+                        ls.push(`<div class="user-card" title="${friends[i]["description"]}"><a class="card-link" href="${friends[i]["url"]}" rel="external nofollow noopener noreferrer" target="_blank"><img onError="this.src='https://gcore.jsdelivr.net/gh/cdn-x/placeholder@1.0.4/avatar/round/3442075.svg';" src="${friends[i]["image"]}"><div class="name"><span>${friends[i]["name"]}</span></div></a></div>`);
                     }
-                    document.getElementById(id).innerHTML = "<div class=\"grid-box\">" + content + "</div></div>";
+                    ls.push('</div>')
+                    document.getElementById(id).innerHTML = ls.join('') + "</div>";
                 } else {
                     alert("友链载入失败!");
                 }

--- a/Stellar/friends.js
+++ b/Stellar/friends.js
@@ -1,7 +1,7 @@
 function loadQexoFriends(id, url) {
     var uri = url + "/pub/friends/";
     var loadStyle = '<div style="text-align: center;margin-top: 10px;width: 100%;" class="qexo_loading"><div class="qexo_part"><div style="display: flex; justify-content: center"><div class="qexo_loader"><div class="qexo_inner one"></div><div class="qexo_inner two"></div><div class="qexo_inner three"></div></div></div></div><p style="text-align: center; display: block">友链加载中...</p></div><center>';
-    document.getElementById(id).className = "friend-content tag-plugin users-wrap";
+    document.getElementById(id).className = "tag-plugin users-wrap";
     document.getElementById(id).innerHTML = loadStyle;
     fetch(uri).then(function(data){
         if (data.ok){
@@ -12,7 +12,7 @@ function loadQexoFriends(id, url) {
                     for (let i = 0; i < friends.length; i++) {
                         content = `<div class="user-card" title="${friends[i]["description"]}"><a class="card-link" href="${friends[i]["url"]}" rel="external nofollow noopener noreferrer" target="_blank"><img onError="this.src='https://gcore.jsdelivr.net/gh/cdn-x/placeholder@1.0.4/avatar/round/3442075.svg';" src="${friends[i]["image"]}"><div class="name"><span>${friends[i]["name"]}</span></div></a></div>`;
                     }
-                    document.getElementById(id).innerHTML = content + "</div>";
+                    document.getElementById(id).innerHTML = "<div class=\"grid-box\">" + content + "</div></div>";
                 } else {
                     alert("友链载入失败!");
                 }


### PR DESCRIPTION
修复了Stellar Theme 版本1.22以上使用Qexo友链导致的图标异常
![image](https://github.com/Qexo/Qexo-Friends/assets/128666602/a6e85b20-ee5e-4037-8bb2-39d72cb4972c)
